### PR TITLE
cache client status to prevent over polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stretch_remote
 
-Python library to remotely command and listen to stretch robot.
+Python library to remotely control and listen to a stretch robot.
 
 ## Quick Start
 
@@ -36,7 +36,6 @@ print(s)
 
 # Move the robot
 # dict is described in absolute joint angles:
-# 
 rc.move({'y': 0.1})
 ```
 

--- a/stretch_remote/remote_client.py
+++ b/stretch_remote/remote_client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import time
 import json
 from typing import Dict, List, Optional
 
@@ -8,7 +9,7 @@ from stretch_remote.robot_utils import read_robot_status
 
 # Default home dict
 HOME_POS_DICT = {
-        'y': 0.1, 'z': 0.75, 'roll': 0, 'pitch': -0.3, 'yaw': 0, 'gripper': 55
+        'x': 0, 'y': 0.1, 'z': 0.75, 'roll': 0, 'pitch': -0.3, 'yaw': 0, 'gripper': 55
     }
 
 ##############################################################################
@@ -22,22 +23,42 @@ class RemoteClient:
         """
         self.socket_client = SocketClient(ip=ip, port=port)
         self.home_dict = home_dict
+        
+        # related to caching the status
+        self.status_poll_limit = 1.0 / 15  # 15 hz limit
+        self.cache_status = None # Cache the status and return it if more than 30 hz
+        self.latest_poll = time.time()
 
     def home(self):
         """Robot goes back home"""
         s = json.dumps({"move": self.home_dict, "compact_status": True})
         self.socket_client.send_payload(s)
 
-    def get_status(self, compact=False) -> Optional[Dict]:
+    def get_status(self,
+                   compact=False,
+                   return_cache_status=True
+                   ) -> Optional[Dict]:
         """
         Get the current status of the robot
         :arg compact: if True, only return compact dict
+        :arg cache_status: if True, cache the status to prevent overpolling
         :return: dict of the robot status
         """
         s = json.dumps({"compact_status": compact})
+        
+        # return cached status if the time is less than the poll limit
+        if return_cache_status and \
+            time.time() - self.latest_poll < self.status_poll_limit and \
+            self.cache_status is not None:
+            # TODO: compact and non-compact status cache differently
+            return self.cache_status
+
         s = self.socket_client.send_payload(s)
         if s is None:
             return None
+
+        self.cache_status = json.loads(s)
+        self.latest_poll = time.time()
         return json.loads(s)
 
     def move(self, description: Dict):

--- a/stretch_remote/remote_client.py
+++ b/stretch_remote/remote_client.py
@@ -50,8 +50,11 @@ class RemoteClient:
         if return_cache_status and \
             time.time() - self.latest_poll < self.status_poll_limit and \
             self.cache_status is not None:
-            # TODO: compact and non-compact status cache differently
-            return self.cache_status
+            # NOTE: better way to identify 
+            # compact and non-compact status cache differently
+            is_compact = "pimu" in self.cache_status
+            if is_compact == compact:
+                return self.cache_status
 
         s = self.socket_client.send_payload(s)
         if s is None:
@@ -73,7 +76,4 @@ class RemoteClient:
         s = self.socket_client.send_payload(s)
         if s is None:
             return None
-        # save the status to cache
-        self.cache_status = json.loads(s)
-        self.latest_poll = time.time()
         return json.loads(s)

--- a/stretch_remote/remote_client.py
+++ b/stretch_remote/remote_client.py
@@ -70,7 +70,7 @@ class RemoteClient:
         """
         # print("Moving robot to", description)
         s = json.dumps({"move": description, "compact_status": True})
-        self.socket_client.send_payload(s)
+        s = self.socket_client.send_payload(s)
         if s is None:
             return None
         # save the status to cache

--- a/stretch_remote/robot_server.py
+++ b/stretch_remote/robot_server.py
@@ -15,8 +15,8 @@ class RobotControlServer:
         self.robot = stretch_body.robot.Robot()
         self.robot.startup()
 
-        self.arm_vel = 0.15 * speed_factor
-        self.arm_accel = 0.15 * speed_factor
+        self.arm_vel = 0.2 * speed_factor
+        self.arm_accel = 0.2 * speed_factor
 
         # NOTE: the wrist velocity are not actually working
         self.wrist_vel = 0.0001 * speed_factor

--- a/teleop.py
+++ b/teleop.py
@@ -71,9 +71,9 @@ def teleop(client: RemoteClient):
             break
 
         # print("Input received:", input_char, "\n")
-        _robot_status = client.get_status()
+        _robot_status = client.get_status(compact=True)
         if _robot_status is not None:
-            pos_dict = read_robot_status(_robot_status)
+            pos_dict = _robot_status
         # print("Current position:", pos_dict)
 
         if keycode == ' ':     # toggle moving


### PR DESCRIPTION
- Client side API might over poll the `get_status()` method. This is to cache the status with 15 hz limit to prevent overpolling